### PR TITLE
Add Render YAML JSON schema

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -5049,6 +5049,12 @@
       "url": "https://raw.githubusercontent.com/arvinxx/components/master/packages/journey-map/schema/journey-map.schema.json"
     },
     {
+      "name": "Render Blueprints",
+      "description": "Blueprints are Render’s infrastructure-as-code model for defining, deploying, and managing multiple resources with a single YAML file.",
+      "fileMatch": ["**/*render.yaml"],
+      "url": "https://render.com/schema/render.yaml.json"
+    },
+    {
       "name": "RKE Cluster Configuration YAML",
       "description": "the cluster.yml configuration file for RKE",
       "fileMatch": ["cluster.yml", "cluster.yaml"],


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to SchemaStore.

Before continuing, please read the guidelines:
https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md

Adding a JSON schema file to the catalog is required.
Add tests files. (.json, .yml, .yaml or .toml)
Use the most recent JSON Schema version that's well supported by editors and IDEs, currently draft-07.
JSON formatted according to the .editorconfig settings.

-->
[Blueprints](https://docs.render.com/infrastructure-as-code) are Render’s infrastructure-as-code model for defining, deploying, and managing multiple resources with a single YAML file. 

This PR adds an entry pointing at the JSON schema for Render blueprint files.